### PR TITLE
feat : (2) 좋아요 모아보기 기능 및 정렬 조건 추가, 유저의 후기 작성 현황 체크

### DIFF
--- a/src/main/java/inu/codin/codin/domain/lecture/controller/LectureController.java
+++ b/src/main/java/inu/codin/codin/domain/lecture/controller/LectureController.java
@@ -18,7 +18,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/lectures")
 @RequiredArgsConstructor
 @Tag(name = "Lecture API", description = "강의실 정보 API")
 public class LectureController {

--- a/src/main/java/inu/codin/codin/domain/lecture/controller/LectureController.java
+++ b/src/main/java/inu/codin/codin/domain/lecture/controller/LectureController.java
@@ -53,11 +53,12 @@ public class LectureController {
                 .body(new SingleResponse<>(200, "강의 별점 정보 반환", lectureService.getLectureDetails(lectureId)));
     }
 
-    @Hidden
     @Operation(
             summary = "학과, 학년, 수강학기 로 강의 검색",
             description = "수강 후기 작성 시 필요한 검색엔진<br>" +
-                    "학과, 학년, 수강학기 중 하나만으로도 검색 가능"
+                    "학과(COMPUTER_SCI, INFO_COMM, EMBEDDED) <br>" +
+                    "학년(1,2,3,4) <br>" +
+                    "수강학기(25-1 ~ )중 하나만으로도 검색 가능"
     )
     @GetMapping("/search-review")
     public ResponseEntity<ListResponse<LectureSearchListResponseDto>> searchLecturesToReview(@RequestParam(required = false) Department department,

--- a/src/main/java/inu/codin/codin/domain/lecture/controller/LectureController.java
+++ b/src/main/java/inu/codin/codin/domain/lecture/controller/LectureController.java
@@ -8,6 +8,7 @@ import inu.codin.codin.domain.lecture.service.LectureService;
 import inu.codin.codin.global.common.entity.Department;
 import inu.codin.codin.global.common.response.ListResponse;
 import inu.codin.codin.global.common.response.SingleResponse;
+import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.constraints.Max;
@@ -29,21 +30,23 @@ public class LectureController {
             description = "학과명과 검색 키워드(optional), 과목/교수 라디오 토클을 통해 정렬한 리스트 10개씩 반환<br>"+
                     "department : COMPUTER_SCI, INFO_COMM, EMBEDDED <br>"+
                     "keyword : 검색 키워드 (Optional)"+
-                    "sort : RATING(평점 높은 순) , LIKE(좋아요 많은 순), HIT(조회수 많은 순)"
+                    "sort : RATING(평점 높은 순) , LIKE(좋아요 많은 순), HIT(조회수 많은 순) <br>"+
+                    "like : 좋아요한 과목 모아보기 true"
     )
     @GetMapping("/courses")
     public ResponseEntity<SingleResponse<LecturePageResponse>> sortListOfLectures(@RequestParam(value = "department", required = false) Department department,
                                                                                   @RequestParam(value = "keyword", required = false) String keyword,
                                                                                   @RequestParam(value = "sort", required = false) SortingOption sort,
+                                                                                  @RequestParam(value = "like", required = false) Boolean like,
                                                                                   @RequestParam("page") int page){
         return ResponseEntity.ok()
                 .body(new SingleResponse<>(200, "과목 리스트 반환 완료",
-                        lectureService.sortListOfLectures(keyword, department, sort, page)));
+                        lectureService.sortListOfLectures(keyword, department, sort, like, page)));
     }
 
     @Operation(
-            summary = "강의 상세 정보 반환",
-            description = "강의 Preview를 눌렀을 때 뜨는 강의 정보 반환"
+            summary = "과목 상세 정보 반환",
+            description = "Preview를 눌렀을 때 뜨는 과목 정보 반환"
     )
     @GetMapping("/{lectureId}")
     public ResponseEntity<SingleResponse<LectureDetailResponseDto>> getLectureDetails(@PathVariable("lectureId") Long lectureId){
@@ -51,6 +54,7 @@ public class LectureController {
                 .body(new SingleResponse<>(200, "강의 별점 정보 반환", lectureService.getLectureDetails(lectureId)));
     }
 
+    @Hidden
     @Operation(
             summary = "학과, 학년, 수강학기 로 강의 검색",
             description = "수강 후기 작성 시 필요한 검색엔진<br>" +

--- a/src/main/java/inu/codin/codin/domain/lecture/controller/LectureRoomController.java
+++ b/src/main/java/inu/codin/codin/domain/lecture/controller/LectureRoomController.java
@@ -14,7 +14,7 @@ import org.springframework.web.bind.annotation.RestController;
 import java.util.List;
 import java.util.Map;
 
-@RequestMapping("/lectures/rooms")
+@RequestMapping("/rooms")
 @RestController
 @RequiredArgsConstructor
 @Tag(name = "Lecture Room API", description = "강의실 현황 API")

--- a/src/main/java/inu/codin/codin/domain/lecture/controller/LectureUploadController.java
+++ b/src/main/java/inu/codin/codin/domain/lecture/controller/LectureUploadController.java
@@ -16,7 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
 @RestController
-@RequestMapping("/lectures/upload")
+@RequestMapping("/upload")
 @RequiredArgsConstructor
 @Tag(name = "Lecture Upload API", description = "강의 내역 및 강의실 현황 업데이트 API")
 public class LectureUploadController {

--- a/src/main/java/inu/codin/codin/domain/lecture/dto/LectureDetailResponseDto.java
+++ b/src/main/java/inu/codin/codin/domain/lecture/dto/LectureDetailResponseDto.java
@@ -34,7 +34,9 @@ public class LectureDetailResponseDto extends LecturePreviewResponseDto {
     @Schema(description = "후기 평점들의 범위마다 100분율 계산", example = "hard : 30, ok : 20, best : 50")
     private EmotionResponseDto emotion;
 
-    public LectureDetailResponseDto(String id, String title, String professor, Type type, int grade, int credit, List<String> tags, Department department, Department college, String evaluation, String lectureType, List<Schedule> schedule, String preCourse, EmotionResponseDto emotion) {
+    private boolean openKeyword;
+
+    public LectureDetailResponseDto(String id, String title, String professor, Type type, int grade, int credit, List<String> tags, Department department, Department college, String evaluation, String lectureType, List<Schedule> schedule, String preCourse, EmotionResponseDto emotion, boolean openKeyword) {
         super(id, title, professor, type, grade, credit, tags, null);
         this.department = department.getDescription();
         this.college = college.getDescription();
@@ -43,9 +45,10 @@ public class LectureDetailResponseDto extends LecturePreviewResponseDto {
         this.schedule = schedule;
         this.preCourse = preCourse;
         this.emotion = emotion;
+        this.openKeyword = openKeyword;
     }
 
-    public static LectureDetailResponseDto of(Lecture lecture){
+    public static LectureDetailResponseDto of(Lecture lecture, boolean openKeyword){
         List<Schedule> schedules = lecture.getSchedule().stream().map(Schedule::of).toList();
         List<String> tags = LecturePreviewResponseDto.getTags(lecture.getTags());
         return new LectureDetailResponseDto(
@@ -62,7 +65,8 @@ public class LectureDetailResponseDto extends LecturePreviewResponseDto {
                 lecture.getLectureType(),
                 schedules,
                 lecture.getPreCourse(),
-                lecture.getEmotion().changeToPercentage()
+                lecture.getEmotion().changeToPercentage(),
+                openKeyword
         );
     }
     

--- a/src/main/java/inu/codin/codin/domain/lecture/dto/LectureDetailResponseDto.java
+++ b/src/main/java/inu/codin/codin/domain/lecture/dto/LectureDetailResponseDto.java
@@ -13,9 +13,6 @@ import java.util.List;
 @Getter
 public class LectureDetailResponseDto extends LecturePreviewResponseDto {
 
-    @Schema(description = "학부", example = "컴퓨터공학부")
-    private String department;
-
     @Schema(description = "단과대", example = "정보기술대학")
     private String college;
 
@@ -36,9 +33,8 @@ public class LectureDetailResponseDto extends LecturePreviewResponseDto {
 
     private boolean openKeyword;
 
-    public LectureDetailResponseDto(String id, String title, String professor, Type type, int grade, int credit, List<String> tags, Department department, Department college, String evaluation, String lectureType, List<Schedule> schedule, String preCourse, EmotionResponseDto emotion, boolean openKeyword) {
-        super(id, title, professor, type, grade, credit, tags, null);
-        this.department = department.getDescription();
+    public LectureDetailResponseDto(String id, String title, String professor, Type type, int grade, int credit, List<String> tags, Department department, Department college, String evaluation, String lectureType, List<Schedule> schedule, String preCourse, EmotionResponseDto emotion, boolean openKeyword, int likes) {
+        super(id, title, professor, type, grade, credit, tags, null, department.getDescription(), likes);
         this.college = college.getDescription();
         this.evaluation = evaluation;
         this.lectureType = lectureType;
@@ -66,7 +62,8 @@ public class LectureDetailResponseDto extends LecturePreviewResponseDto {
                 schedules,
                 lecture.getPreCourse(),
                 lecture.getEmotion().changeToPercentage(),
-                openKeyword
+                openKeyword,
+                lecture.getLikes()
         );
     }
     

--- a/src/main/java/inu/codin/codin/domain/lecture/dto/LectureDetailResponseDto.java
+++ b/src/main/java/inu/codin/codin/domain/lecture/dto/LectureDetailResponseDto.java
@@ -1,5 +1,6 @@
 package inu.codin.codin.domain.lecture.dto;
 
+import inu.codin.codin.domain.lecture.entity.Emotion;
 import inu.codin.codin.domain.lecture.entity.Lecture;
 import inu.codin.codin.domain.lecture.entity.LectureSchedule;
 import inu.codin.codin.domain.lecture.entity.Type;
@@ -33,7 +34,7 @@ public class LectureDetailResponseDto extends LecturePreviewResponseDto {
 
     private boolean openKeyword;
 
-    public LectureDetailResponseDto(String id, String title, String professor, Type type, int grade, int credit, List<String> tags, Department department, Department college, String evaluation, String lectureType, List<Schedule> schedule, String preCourse, EmotionResponseDto emotion, boolean openKeyword, int likes) {
+    public LectureDetailResponseDto(Long id, String title, String professor, Type type, int grade, int credit, List<String> tags, Department department, Department college, String evaluation, String lectureType, List<Schedule> schedule, String preCourse, EmotionResponseDto emotion, boolean openKeyword, int likes) {
         super(id, title, professor, type, grade, credit, tags, null, department.getDescription(), likes);
         this.college = college.getDescription();
         this.evaluation = evaluation;
@@ -44,11 +45,11 @@ public class LectureDetailResponseDto extends LecturePreviewResponseDto {
         this.openKeyword = openKeyword;
     }
 
-    public static LectureDetailResponseDto of(Lecture lecture, boolean openKeyword){
+    public static LectureDetailResponseDto of(Lecture lecture, Emotion emotion, boolean openKeyword){
         List<Schedule> schedules = lecture.getSchedule().stream().map(Schedule::of).toList();
         List<String> tags = LecturePreviewResponseDto.getTags(lecture.getTags());
         return new LectureDetailResponseDto(
-                lecture.getId().toString(),
+                lecture.getId(),
                 lecture.getLectureNm(),
                 lecture.getProfessor(),
                 lecture.getType(),
@@ -61,7 +62,7 @@ public class LectureDetailResponseDto extends LecturePreviewResponseDto {
                 lecture.getLectureType(),
                 schedules,
                 lecture.getPreCourse(),
-                lecture.getEmotion().changeToPercentage(),
+                emotion.changeToPercentage(),
                 openKeyword,
                 lecture.getLikes()
         );

--- a/src/main/java/inu/codin/codin/domain/lecture/dto/LecturePreviewResponseDto.java
+++ b/src/main/java/inu/codin/codin/domain/lecture/dto/LecturePreviewResponseDto.java
@@ -3,6 +3,7 @@ package inu.codin.codin.domain.lecture.dto;
 import inu.codin.codin.domain.lecture.entity.Lecture;
 import inu.codin.codin.domain.lecture.entity.LectureTag;
 import inu.codin.codin.domain.lecture.entity.Type;
+import inu.codin.codin.global.common.entity.Department;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
@@ -39,8 +40,15 @@ public class LecturePreviewResponseDto {
     @Schema(description = "유저의 좋아요 여부", example = "true")
     private Boolean liked;
 
+    @Schema(description = "학과", example = "컴퓨터공학부")
+    private String department;
+
+    @Schema(description = "좋아요 수", example = "3")
+    private int likes;
+
+
     @Builder
-    public LecturePreviewResponseDto(String id, String title, String professor, Type type, int grade, int credit, List<String> tags, Boolean liked) {
+    public LecturePreviewResponseDto(String id, String title, String professor, Type type, int grade, int credit, List<String> tags, Boolean liked, String department, int likes) {
         this.id = id;
         this.title = title;
         this.professor = professor;
@@ -49,6 +57,8 @@ public class LecturePreviewResponseDto {
         this.credit = credit;
         this.tags = tags;
         this.liked = liked;
+        this.department = department;
+        this.likes = likes;
     }
 
     public static LecturePreviewResponseDto of(Lecture lecture, boolean liked){
@@ -61,6 +71,8 @@ public class LecturePreviewResponseDto {
                 .credit(lecture.getCredit())
                 .tags(getTags(lecture.getTags()))
                 .liked(liked)
+                .department(lecture.getDepartment().getDescription())
+                .likes(lecture.getLikes())
                 .build();
     }
 

--- a/src/main/java/inu/codin/codin/domain/lecture/dto/LecturePreviewResponseDto.java
+++ b/src/main/java/inu/codin/codin/domain/lecture/dto/LecturePreviewResponseDto.java
@@ -16,8 +16,8 @@ import java.util.Set;
 @Getter
 public class LecturePreviewResponseDto {
 
-    @Schema(description = "과목코드", example = "IAA6018")
-    private String id;
+    @Schema(description = "과목 pk", example = "1")
+    private Long id;
 
     @Schema(description = "과목명", example = "운영체제")
     private String title;
@@ -48,7 +48,7 @@ public class LecturePreviewResponseDto {
 
 
     @Builder
-    public LecturePreviewResponseDto(String id, String title, String professor, Type type, int grade, int credit, List<String> tags, Boolean liked, String department, int likes) {
+    public LecturePreviewResponseDto(Long id, String title, String professor, Type type, int grade, int credit, List<String> tags, Boolean liked, String department, int likes) {
         this.id = id;
         this.title = title;
         this.professor = professor;
@@ -63,7 +63,7 @@ public class LecturePreviewResponseDto {
 
     public static LecturePreviewResponseDto of(Lecture lecture, boolean liked){
         return LecturePreviewResponseDto.builder()
-                .id(lecture.getId().toString())
+                .id(lecture.getId())
                 .title(lecture.getLectureNm())
                 .professor(lecture.getProfessor())
                 .type(lecture.getType())

--- a/src/main/java/inu/codin/codin/domain/lecture/dto/LectureSearchListResponseDto.java
+++ b/src/main/java/inu/codin/codin/domain/lecture/dto/LectureSearchListResponseDto.java
@@ -1,6 +1,8 @@
 package inu.codin.codin.domain.lecture.dto;
 
 import inu.codin.codin.domain.lecture.entity.Lecture;
+import inu.codin.codin.domain.lecture.entity.LectureSemester;
+import inu.codin.codin.domain.lecture.entity.Semester;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -10,14 +12,14 @@ import java.util.List;
 @Getter
 public class LectureSearchListResponseDto {
 
-    private String _id;
+    private Long id;
     private String lectureNm;
     private String professor;
     private String semester;
 
     @Builder
-    public LectureSearchListResponseDto(String _id, String lectureNm, String professor, String semester) {
-        this._id = _id;
+    public LectureSearchListResponseDto(Long id, String lectureNm, String professor, String semester) {
+        this.id = id;
         this.lectureNm = lectureNm;
         this.professor = professor;
         this.semester = semester;
@@ -26,14 +28,14 @@ public class LectureSearchListResponseDto {
 
     public static List<LectureSearchListResponseDto> of(Lecture lecture) {
         List<LectureSearchListResponseDto> listResponseDtos = new ArrayList<>();
-//        for (String semester: lecture.getSemester()){
-//            listResponseDtos.add(LectureSearchListResponseDto.builder()
-//                    ._id(lecture.get_id().toString())
-//                    .lectureNm(lecture.getLectureNm())
-//                    .professor(lecture.getProfessor())
-//                    .semester(semester)
-//                    .build());
-//        }
+        for (LectureSemester semester: lecture.getSemester()){
+            listResponseDtos.add(LectureSearchListResponseDto.builder()
+                    .id(lecture.getId())
+                    .lectureNm(lecture.getLectureNm())
+                    .professor(lecture.getProfessor())
+                    .semester(semester.getSemester().getString())
+                    .build());
+        }
         return listResponseDtos;
     }
 

--- a/src/main/java/inu/codin/codin/domain/lecture/entity/Emotion.java
+++ b/src/main/java/inu/codin/codin/domain/lecture/entity/Emotion.java
@@ -27,6 +27,7 @@ public class Emotion {
         this.ok = 0;
         this.best = 0;
         this.lecture = lecture;
+        lecture.assignEmotion(this);
     }
 
     public EmotionResponseDto changeToPercentage(){

--- a/src/main/java/inu/codin/codin/domain/lecture/entity/Lecture.java
+++ b/src/main/java/inu/codin/codin/domain/lecture/entity/Lecture.java
@@ -39,7 +39,8 @@ public class Lecture {
     private int hits;                                           //조회 수
 
     @OneToOne
-    private Emotion emotion = new Emotion(this);        //수강 후기의 평점 분포도
+    @JoinColumn(name = "emotion_id")
+    private Emotion emotion;                                    //수강 후기의 평점 분포도
 
     @OneToMany(mappedBy = "lecture", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     private Set<LectureSemester> semester;                      //과목이 진행된 학기
@@ -63,6 +64,10 @@ public class Lecture {
 
     public void updateReviewRating(double starRating, Emotion emotion) {
         this.starRating = starRating;
+        this.emotion = emotion;
+    }
+
+    public void setEmotion(Emotion emotion) {
         this.emotion = emotion;
     }
 }

--- a/src/main/java/inu/codin/codin/domain/lecture/entity/Lecture.java
+++ b/src/main/java/inu/codin/codin/domain/lecture/entity/Lecture.java
@@ -33,7 +33,7 @@ public class Lecture {
 
     @Convert(converter = EvaluationConverter.class)
     private Evaluation evaluation;                              //평가 방식(상대평가, 절대평가, 이수)
-    private String preCourse;                                   //사전 과목
+    private String preCourse;                                   //사전 과목 //todo List로 관리 피룡
     private double starRating;                                  //과목 평점
     private int likes;                                          //좋아요 수
     private int hits;                                           //조회 수
@@ -67,7 +67,7 @@ public class Lecture {
         this.emotion = emotion;
     }
 
-    public void setEmotion(Emotion emotion) {
+    public void assignEmotion(Emotion emotion) {
         this.emotion = emotion;
     }
 }

--- a/src/main/java/inu/codin/codin/domain/lecture/entity/LectureType.java
+++ b/src/main/java/inu/codin/codin/domain/lecture/entity/LectureType.java
@@ -1,8 +1,0 @@
-package inu.codin.codin.domain.lecture.entity;
-
-import lombok.Getter;
-
-@Getter
-public enum LectureType {
-    FACE_TO_FACE
-}

--- a/src/main/java/inu/codin/codin/domain/lecture/entity/Semester.java
+++ b/src/main/java/inu/codin/codin/domain/lecture/entity/Semester.java
@@ -25,4 +25,9 @@ public class Semester {
     public String getString() {
         return year + "-" + quarter;
     }
+
+    public static int[] parseSemester(String semesterStr) {
+        String[] parts = semesterStr.split("-");
+        return new int[]{Integer.parseInt(parts[0]), Integer.parseInt(parts[1])};
+    }
 }

--- a/src/main/java/inu/codin/codin/domain/lecture/entity/Semester.java
+++ b/src/main/java/inu/codin/codin/domain/lecture/entity/Semester.java
@@ -25,9 +25,4 @@ public class Semester {
     public String getString() {
         return year + "-" + quarter;
     }
-
-    public static int[] parseSemester(String semesterStr) {
-        String[] parts = semesterStr.split("-");
-        return new int[]{Integer.parseInt(parts[0]), Integer.parseInt(parts[1])};
-    }
 }

--- a/src/main/java/inu/codin/codin/domain/lecture/repository/LectureSearchRepositoryCustom.java
+++ b/src/main/java/inu/codin/codin/domain/lecture/repository/LectureSearchRepositoryCustom.java
@@ -5,8 +5,7 @@ import inu.codin.codin.domain.lecture.entity.SortingOption;
 import inu.codin.codin.global.common.entity.Department;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.stereotype.Repository;
 
 public interface LectureSearchRepositoryCustom {
-    Page<Lecture> search(String keyword, Department department, SortingOption sortingOption, Pageable pageable);
+    Page<Lecture> search(String keyword, Department department, SortingOption sortingOption, Boolean like, Pageable pageable);
 }

--- a/src/main/java/inu/codin/codin/domain/lecture/repository/LectureSearchRepositoryCustom.java
+++ b/src/main/java/inu/codin/codin/domain/lecture/repository/LectureSearchRepositoryCustom.java
@@ -10,7 +10,7 @@ import org.springframework.data.domain.Pageable;
 import java.util.List;
 
 public interface LectureSearchRepositoryCustom {
-    Page<Lecture> searchLecturesAtPreview(String keyword, Department department, SortingOption sortingOption, Boolean like, Pageable pageable);
+    Page<Lecture> searchLecturesAtPreview(String keyword, Department department, SortingOption sortingOption, List<Long> liked, Pageable pageable);
 
     List<Lecture> searchLecturesAtReview(Department department, Integer grade, Semester semester);
 }

--- a/src/main/java/inu/codin/codin/domain/lecture/repository/LectureSearchRepositoryCustom.java
+++ b/src/main/java/inu/codin/codin/domain/lecture/repository/LectureSearchRepositoryCustom.java
@@ -1,11 +1,16 @@
 package inu.codin.codin.domain.lecture.repository;
 
 import inu.codin.codin.domain.lecture.entity.Lecture;
+import inu.codin.codin.domain.lecture.entity.Semester;
 import inu.codin.codin.domain.lecture.entity.SortingOption;
 import inu.codin.codin.global.common.entity.Department;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.util.List;
+
 public interface LectureSearchRepositoryCustom {
-    Page<Lecture> search(String keyword, Department department, SortingOption sortingOption, Boolean like, Pageable pageable);
+    Page<Lecture> searchLecturesAtPreview(String keyword, Department department, SortingOption sortingOption, Boolean like, Pageable pageable);
+
+    List<Lecture> searchLecturesAtReview(Department department, Integer grade, Semester semester);
 }

--- a/src/main/java/inu/codin/codin/domain/lecture/repository/LectureSearchRepositoryImpl.java
+++ b/src/main/java/inu/codin/codin/domain/lecture/repository/LectureSearchRepositoryImpl.java
@@ -3,6 +3,7 @@ package inu.codin.codin.domain.lecture.repository;
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.jpa.JPQLQuery;
+import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import inu.codin.codin.domain.lecture.entity.*;
 import inu.codin.codin.domain.lecture.exception.LectureErrorCode;
@@ -27,19 +28,68 @@ public class LectureSearchRepositoryImpl implements LectureSearchRepositoryCusto
     private final LikeFeignClient likeFeignClient;
 
     @Override
-    public Page<Lecture> search(String keyword, Department department, SortingOption sortingOption, Boolean like, Pageable pageable) {
+    public Page<Lecture> searchLecturesAtPreview(String keyword, Department department, SortingOption sortingOption, Boolean like, Pageable pageable) {
         QLecture lecture = QLecture.lecture;
         QTag tag = QTag.tag;
         QLectureTag lectureTag = QLectureTag.lectureTag;
 
         BooleanBuilder builder = new BooleanBuilder();
 
-        if (department != null) {
-            validDepartment(department);
-            builder.and(lecture.department.eq(department));
+        searchByDepartment(department, builder, lecture); //학과 조건 추가
+        searchByKeyword(keyword, builder, lecture, lectureTag); //키워드 조건 추가
+        Page<Lecture> resultOfLiked = searchByOnlyUserLiked(like, pageable, builder, lecture); //좋아요 조건 추가
+        if (resultOfLiked != null) return resultOfLiked;
+
+        OrderSpecifier<?> orderSpecifier = getOrderSpecifier(lecture, sortingOption); //정렬 조건 추가
+
+        JPQLQuery<Lecture> query = jpaQueryFactory
+                .selectDistinct(lecture)
+                .from(lecture);
+
+        JPAQuery<Long> countQuery = jpaQueryFactory
+                .select(lecture.countDistinct())
+                .from(lecture);
+
+        if (keyword != null && !keyword.isBlank()) { //키워드가 존재한다면 tags에 대하여 left Join 진행
+            applyTagJoins(query, lecture, lectureTag, tag);
+            applyTagJoins(countQuery, lecture, lectureTag, tag);
         }
 
-        if (keyword != null && !keyword.isBlank()){
+        //조건에 맞는 강의들에 대해서만 필터링
+        query.where(builder)
+                .orderBy(orderSpecifier != null ? orderSpecifier : lecture.id.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize());
+
+        List<Lecture> lectures = query.fetch();
+
+        Long total = countQuery
+                .where(builder)
+                .fetchOne();
+
+        return new PageImpl<>(lectures, pageable, total != null? total : 0);
+    }
+
+    private void applyTagJoins(JPQLQuery<?> query, QLecture lecture, QLectureTag lectureTag, QTag tag) {
+        query.leftJoin(lecture.tags, lectureTag)
+                .leftJoin(lectureTag.tag, tag);
+    }
+
+    private Page<Lecture> searchByOnlyUserLiked(Boolean like, Pageable pageable, BooleanBuilder builder, QLecture lecture) {
+        if (like != null && like) { //좋아요가 true라면 좋아요한 강의의 id를 통해 결과 필터링
+            String userId = SecurityUtils.getUserId();
+            List<Long> liked = likeFeignClient.getLiked(LikeType.LECTURE, userId).stream()
+                    .map(likedResponseDto -> Long.valueOf(likedResponseDto.getLikeTypeId())).toList();
+            if (liked.isEmpty()) {
+                return Page.empty(pageable);
+            }
+            builder.and(lecture.id.in(liked));
+        }
+        return null;
+    }
+
+    private void searchByKeyword(String keyword, BooleanBuilder builder, QLecture lecture, QLectureTag lectureTag) {
+        if (keyword != null && !keyword.isBlank()){ //키워드가 있다면 모든 정보에 대해서 확인
             builder.andAnyOf(
                     lecture.lectureNm.containsIgnoreCase(keyword),
                     lecture.lectureType.containsIgnoreCase(keyword),
@@ -48,48 +98,39 @@ public class LectureSearchRepositoryImpl implements LectureSearchRepositoryCusto
                     lecture.type.stringValue().containsIgnoreCase(keyword),
                     lecture.professor.containsIgnoreCase(keyword),
                     lectureTag.tag.tagName.containsIgnoreCase(keyword)
+                    //todo 이후에 추가될 수 있는 필드들에 대해서도 조건 추가
             );
         }
+    }
 
-        if (like != null && like) {
-            String userId = SecurityUtils.getUserId();
-            List<Long> liked = likeFeignClient.getLiked(LikeType.LECTURE, userId).stream()
-                    .map(likedResponseDto -> Long.valueOf(likedResponseDto.getLikeTypeId())).toList();
+    private void searchByDepartment(Department department, BooleanBuilder builder, QLecture lecture) {
+        if (department != null) { //학과에 대한 정렬이 필요하다면 검증 후 조건 추가
+            validDepartment(department);
+            builder.and(lecture.department.eq(department));
+        }
+    }
 
-            if (liked.isEmpty()) {
-                return Page.empty(pageable);
-            }
+    @Override
+    public List<Lecture> searchLecturesAtReview(Department department, Integer grade, Semester semester) {
+        QLecture lecture = QLecture.lecture;
 
-            builder.and(lecture.id.in(liked));
+        BooleanBuilder builder = new BooleanBuilder();
+        searchByDepartment(department, builder, lecture);
+        if (grade != null) { //학년이 있다면 조건 추가
+            builder.and(lecture.grade.eq(grade));
         }
 
-        OrderSpecifier<?> orderSpecifier = getOrderSpecifier(lecture, sortingOption);
         JPQLQuery<Lecture> query = jpaQueryFactory
-                .selectDistinct(lecture)
-                .from(lecture);
+                .selectFrom(lecture);
 
-        if (keyword != null && !keyword.isBlank()) {
-            query.leftJoin(lecture.tags, lectureTag)
-                    .leftJoin(lectureTag.tag, tag);
+        if (semester != null) { //학기가 있다면 semester에 대한 join 진행
+            query.leftJoin(lecture.semester).fetchJoin();
+            builder.and(lecture.semester.any().semester.eq(semester));
         }
 
-
-        query.where(builder)
-                .orderBy(orderSpecifier != null ? orderSpecifier : lecture.id.desc())
-                .offset(pageable.getOffset())
-                .limit(pageable.getPageSize());
-
-        List<Lecture> lectures = query.fetch();
-
-        Long total = jpaQueryFactory
-                .select(lecture.countDistinct())
-                .from(lecture)
-                .leftJoin(lecture.tags, lectureTag)
-                .leftJoin(lectureTag.tag, tag)
+        return query
                 .where(builder)
-                .fetchOne();
-
-        return new PageImpl<>(lectures, pageable, total != null? total : 0);
+                .fetch();
     }
 
     private OrderSpecifier<?> getOrderSpecifier(QLecture lecture, SortingOption sortingOption) {

--- a/src/main/java/inu/codin/codin/domain/lecture/service/EmotionService.java
+++ b/src/main/java/inu/codin/codin/domain/lecture/service/EmotionService.java
@@ -5,6 +5,7 @@ import inu.codin.codin.domain.lecture.entity.Lecture;
 import inu.codin.codin.domain.lecture.repository.EmotionRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -12,12 +13,13 @@ public class EmotionService {
 
     private final EmotionRepository emotionRepository;
 
+    @Transactional
     public Emotion getOrMakeEmotion(Lecture lecture) {
-        if (lecture.getEmotion() == null) {
-            Emotion emotion = emotionRepository.save(new Emotion(lecture));
-            lecture.setEmotion(emotion);
-            return emotion;
+        Emotion emotion = lecture.getEmotion();
+        if (emotion == null) {
+            emotion = emotionRepository.save(new Emotion(lecture));
+            lecture.assignEmotion(emotion);
         }
-        return lecture.getEmotion();
+        return emotion;
     }
 }

--- a/src/main/java/inu/codin/codin/domain/lecture/service/EmotionService.java
+++ b/src/main/java/inu/codin/codin/domain/lecture/service/EmotionService.java
@@ -1,0 +1,23 @@
+package inu.codin.codin.domain.lecture.service;
+
+import inu.codin.codin.domain.lecture.entity.Emotion;
+import inu.codin.codin.domain.lecture.entity.Lecture;
+import inu.codin.codin.domain.lecture.repository.EmotionRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class EmotionService {
+
+    private final EmotionRepository emotionRepository;
+
+    public Emotion getOrMakeEmotion(Lecture lecture) {
+        if (lecture.getEmotion() == null) {
+            Emotion emotion = emotionRepository.save(new Emotion(lecture));
+            lecture.setEmotion(emotion);
+            return emotion;
+        }
+        return lecture.getEmotion();
+    }
+}

--- a/src/main/java/inu/codin/codin/domain/lecture/service/LectureService.java
+++ b/src/main/java/inu/codin/codin/domain/lecture/service/LectureService.java
@@ -10,8 +10,9 @@ import inu.codin.codin.domain.lecture.exception.LectureErrorCode;
 import inu.codin.codin.domain.lecture.exception.LectureException;
 import inu.codin.codin.domain.lecture.repository.LectureRepository;
 import inu.codin.codin.domain.lecture.repository.LectureSearchRepositoryCustom;
-import inu.codin.codin.domain.like.service.LikeService;
 import inu.codin.codin.domain.like.dto.LikeType;
+import inu.codin.codin.domain.like.service.LikeService;
+import inu.codin.codin.domain.review.service.UserReviewStatsService;
 import inu.codin.codin.global.common.entity.Department;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -28,6 +29,7 @@ public class LectureService {
     private final LectureRepository lectureRepository;
     private final LectureSearchRepositoryCustom lectureSearchRepository;
 
+    private final UserReviewStatsService userReviewStatsService;
     private final LikeService likeService;
 
     /**
@@ -55,7 +57,8 @@ public class LectureService {
         Lecture lecture = lectureRepository.findLectureWithScheduleAndTagsById(lectureId)
                 .orElseThrow(() -> new LectureException(LectureErrorCode.LECTURE_NOT_FOUND));
         lecture.increaseHits();
-        return LectureDetailResponseDto.of(lecture);
+
+        return LectureDetailResponseDto.of(lecture, userReviewStatsService.isOpenKeyword());
     }
 
     /**

--- a/src/main/java/inu/codin/codin/domain/lecture/service/LectureService.java
+++ b/src/main/java/inu/codin/codin/domain/lecture/service/LectureService.java
@@ -4,6 +4,7 @@ import inu.codin.codin.domain.lecture.dto.LectureDetailResponseDto;
 import inu.codin.codin.domain.lecture.dto.LecturePageResponse;
 import inu.codin.codin.domain.lecture.dto.LecturePreviewResponseDto;
 import inu.codin.codin.domain.lecture.dto.LectureSearchListResponseDto;
+import inu.codin.codin.domain.lecture.entity.Emotion;
 import inu.codin.codin.domain.lecture.entity.Lecture;
 import inu.codin.codin.domain.lecture.entity.Semester;
 import inu.codin.codin.domain.lecture.entity.SortingOption;
@@ -31,8 +32,9 @@ public class LectureService {
 
     private final LectureRepository lectureRepository;
     private final LectureSearchRepositoryCustom lectureSearchRepository;
-    private final SemesterService semesterService;
 
+    private final EmotionService emotionService;
+    private final SemesterService semesterService;
     private final UserReviewStatsService userReviewStatsService;
     private final LikeService likeService;
 
@@ -61,8 +63,8 @@ public class LectureService {
         Lecture lecture = lectureRepository.findLectureWithScheduleAndTagsById(lectureId)
                 .orElseThrow(() -> new LectureException(LectureErrorCode.LECTURE_NOT_FOUND));
         lecture.increaseHits();
-
-        return LectureDetailResponseDto.of(lecture, userReviewStatsService.isOpenKeyword());
+        Emotion emotion = emotionService.getOrMakeEmotion(lecture);
+        return LectureDetailResponseDto.of(lecture, emotion, userReviewStatsService.isOpenKeyword());
     }
 
     /**

--- a/src/main/java/inu/codin/codin/domain/lecture/service/LectureService.java
+++ b/src/main/java/inu/codin/codin/domain/lecture/service/LectureService.java
@@ -5,9 +5,12 @@ import inu.codin.codin.domain.lecture.dto.LecturePageResponse;
 import inu.codin.codin.domain.lecture.dto.LecturePreviewResponseDto;
 import inu.codin.codin.domain.lecture.dto.LectureSearchListResponseDto;
 import inu.codin.codin.domain.lecture.entity.Lecture;
+import inu.codin.codin.domain.lecture.entity.Semester;
 import inu.codin.codin.domain.lecture.entity.SortingOption;
 import inu.codin.codin.domain.lecture.exception.LectureErrorCode;
 import inu.codin.codin.domain.lecture.exception.LectureException;
+import inu.codin.codin.domain.lecture.exception.SemesterErrorCode;
+import inu.codin.codin.domain.lecture.exception.SemesterException;
 import inu.codin.codin.domain.lecture.repository.LectureRepository;
 import inu.codin.codin.domain.lecture.repository.LectureSearchRepositoryCustom;
 import inu.codin.codin.domain.like.dto.LikeType;
@@ -28,6 +31,7 @@ public class LectureService {
 
     private final LectureRepository lectureRepository;
     private final LectureSearchRepositoryCustom lectureSearchRepository;
+    private final SemesterService semesterService;
 
     private final UserReviewStatsService userReviewStatsService;
     private final LikeService likeService;
@@ -43,13 +47,13 @@ public class LectureService {
      * @return LecturePageResponse
      */
     public LecturePageResponse sortListOfLectures(String keyword, Department department, SortingOption sortingOption, Boolean like, int page) {
-        Page<Lecture> lecturePage = lectureSearchRepository.search(keyword, department, sortingOption, like, PageRequest.of(page, 10));
+        Page<Lecture> lecturePage = lectureSearchRepository.searchLecturesAtPreview(keyword, department, sortingOption, like, PageRequest.of(page, 10));
         return getLecturePageResponse(lecturePage);
     }
 
     /**
      * 강의의 상세 별점 반환
-     * @param lectureId 강의 _id
+     * @param lectureId 강의 id
      * @return LectureDetailResponseDto
      */
     @Transactional
@@ -76,27 +80,27 @@ public class LectureService {
 
     /**
      * 강의 후기를 작성할 강의 목록 검색
-     * @param department Department (COMPUTER_SCI, INFO_COMM, EMBEDDED, OTHERS)
+     * @param department Department (COMPUTER_SCI, INFO_COMM, EMBEDDED)
      * @param grade 학년 (1,2,3,4)
      * @param semester 수강 학기 (23-1, 23-2,,, 현재 학기)
      * @return List<LectureSearchListResponseDto> 검색 결과 리스트 반환
      */
     public List<LectureSearchListResponseDto> searchLecturesToReview(Department department, Integer grade, String semester) {
-        List<Lecture> lectures = findLectures(department, grade, semester);
-//        if (semester != null) return lectures.stream()
-//                                    .map(lecture -> LectureSearchListResponseDto.of(lecture, semester))
-//                                    .toList();
+        Semester semesterEntity = (semester != null)
+                        ? semesterService.getSemester(semester)
+                                .orElseThrow(() -> new SemesterException(SemesterErrorCode.SEMESTER_NOT_FOUND))
+                        : null;
 
-        return lectures.stream()
-                .map(LectureSearchListResponseDto::of)
-                .flatMap(List::stream)
-                .toList();
+        List<Lecture> lectures = lectureSearchRepository.searchLecturesAtReview(department, grade, semesterEntity);
+
+        return (semesterEntity != null)
+                ? lectures.stream()
+                        .map(lecture -> LectureSearchListResponseDto.of(lecture, semester))
+                        .toList()
+                : lectures.stream()
+                        .map(LectureSearchListResponseDto::of)
+                        .flatMap(List::stream)
+                        .toList();
     }
 
-    /**
-     * 강의 검색 시 선택된 옵션에 따라 검색 진행
-     */
-    public List<Lecture> findLectures(Department department, Integer grade, String semester) {
-        return List.of();
-    }
 }

--- a/src/main/java/inu/codin/codin/domain/lecture/service/LectureService.java
+++ b/src/main/java/inu/codin/codin/domain/lecture/service/LectureService.java
@@ -49,7 +49,13 @@ public class LectureService {
      * @return LecturePageResponse
      */
     public LecturePageResponse sortListOfLectures(String keyword, Department department, SortingOption sortingOption, Boolean like, int page) {
-        Page<Lecture> lecturePage = lectureSearchRepository.searchLecturesAtPreview(keyword, department, sortingOption, like, PageRequest.of(page, 10));
+        List<Long> liked = null;
+        if (like != null && like) {
+            liked = likeService.getLiked(LikeType.LECTURE).stream()
+                    .map(likedResponseDto -> Long.valueOf(likedResponseDto.getLikeTypeId())).toList();
+        }
+
+        Page<Lecture> lecturePage = lectureSearchRepository.searchLecturesAtPreview(keyword, department, sortingOption, liked, PageRequest.of(page, 10));
         return getLecturePageResponse(lecturePage);
     }
 

--- a/src/main/java/inu/codin/codin/domain/lecture/service/LectureService.java
+++ b/src/main/java/inu/codin/codin/domain/lecture/service/LectureService.java
@@ -12,7 +12,6 @@ import inu.codin.codin.domain.lecture.repository.LectureRepository;
 import inu.codin.codin.domain.lecture.repository.LectureSearchRepositoryCustom;
 import inu.codin.codin.domain.like.service.LikeService;
 import inu.codin.codin.domain.like.dto.LikeType;
-import inu.codin.codin.global.auth.util.SecurityUtils;
 import inu.codin.codin.global.common.entity.Department;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -37,11 +36,12 @@ public class LectureService {
      * @param keyword
      * @param department    Department (COMPUTER_SCI, INFO_COMM, EMBEDDED)
      * @param sortingOption 평점 많은 순, 좋아요 많은 순, 조회수 순 중 내림차순 선택
+     * @param like
      * @param page          페이지 번호
      * @return LecturePageResponse
      */
-    public LecturePageResponse sortListOfLectures(String keyword, Department department, SortingOption sortingOption, int page) {
-        Page<Lecture> lecturePage = lectureSearchRepository.search(keyword, department, sortingOption, PageRequest.of(page, 10));
+    public LecturePageResponse sortListOfLectures(String keyword, Department department, SortingOption sortingOption, Boolean like, int page) {
+        Page<Lecture> lecturePage = lectureSearchRepository.search(keyword, department, sortingOption, like, PageRequest.of(page, 10));
         return getLecturePageResponse(lecturePage);
     }
 

--- a/src/main/java/inu/codin/codin/domain/lecture/service/SemesterService.java
+++ b/src/main/java/inu/codin/codin/domain/lecture/service/SemesterService.java
@@ -17,10 +17,15 @@ public class SemesterService {
 
     public Optional<Semester> getSemester(String semester) {
         try {
-            int [] parsed = Semester.parseSemester(semester);
+            int [] parsed = parseSemester(semester);
             return semesterRepository.findSemesterByYearAndQuarter(parsed[0], parsed[1]);
         } catch (Exception e) {
             throw new SemesterException(SemesterErrorCode.SEMESTER_INVALID_FORMAT);
         }
+    }
+
+    public int[] parseSemester(String semesterStr) {
+        String[] parts = semesterStr.split("-");
+        return new int[]{Integer.parseInt(parts[0]), Integer.parseInt(parts[1])};
     }
 }

--- a/src/main/java/inu/codin/codin/domain/lecture/service/SemesterService.java
+++ b/src/main/java/inu/codin/codin/domain/lecture/service/SemesterService.java
@@ -1,0 +1,26 @@
+package inu.codin.codin.domain.lecture.service;
+
+import inu.codin.codin.domain.lecture.entity.Semester;
+import inu.codin.codin.domain.lecture.exception.SemesterErrorCode;
+import inu.codin.codin.domain.lecture.exception.SemesterException;
+import inu.codin.codin.domain.lecture.repository.SemesterRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class SemesterService {
+
+    private final SemesterRepository semesterRepository;
+
+    public Optional<Semester> getSemester(String semester) {
+        try {
+            int [] parsed = Semester.parseSemester(semester);
+            return semesterRepository.findSemesterByYearAndQuarter(parsed[0], parsed[1]);
+        } catch (Exception e) {
+            throw new SemesterException(SemesterErrorCode.SEMESTER_INVALID_FORMAT);
+        }
+    }
+}

--- a/src/main/java/inu/codin/codin/domain/like/controller/LikeController.java
+++ b/src/main/java/inu/codin/codin/domain/like/controller/LikeController.java
@@ -3,6 +3,7 @@ package inu.codin.codin.domain.like.controller;
 import inu.codin.codin.domain.like.dto.LikeRequestDto;
 import inu.codin.codin.domain.like.dto.LikeResponseType;
 import inu.codin.codin.domain.like.dto.LikeType;
+import inu.codin.codin.domain.like.dto.LikedResponseDto;
 import inu.codin.codin.domain.like.service.LikeService;
 import inu.codin.codin.global.common.response.SingleResponse;
 import io.swagger.v3.oas.annotations.Hidden;
@@ -12,6 +13,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/likes")
@@ -44,5 +47,11 @@ public class LikeController {
     public Boolean isUserLiked(@RequestParam("likeType") LikeType likeType,
                                                          @RequestParam("id") String id) {
         return likeService.isLiked(likeType, id);
+    }
+
+    @Hidden
+    @GetMapping("/list")
+    public List<LikedResponseDto> getLiked(@RequestParam("likeType") LikeType likeType) {
+        return likeService.getLiked(likeType);
     }
 }

--- a/src/main/java/inu/codin/codin/domain/like/controller/LikeFeignClient.java
+++ b/src/main/java/inu/codin/codin/domain/like/controller/LikeFeignClient.java
@@ -3,6 +3,7 @@ package inu.codin.codin.domain.like.controller;
 
 import inu.codin.codin.domain.like.dto.LikeRequestDto;
 import inu.codin.codin.domain.like.dto.LikeType;
+import inu.codin.codin.domain.like.dto.LikedResponseDto;
 import inu.codin.codin.global.common.response.SingleResponse;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.http.ResponseEntity;
@@ -10,6 +11,8 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
+
+import java.util.List;
 
 @FeignClient(name = "likeClient", url = "http://localhost:8080")
 public interface LikeFeignClient {
@@ -25,4 +28,8 @@ public interface LikeFeignClient {
     Boolean isUserLiked(@RequestParam("likeType") LikeType likeType,
                                                     @RequestParam("id") String id,
                                                     @RequestParam("userId") String userId);
+
+    @GetMapping("/likes/list")
+    List<LikedResponseDto> getLiked(@RequestParam("likeType") LikeType likeType,
+                                    @RequestParam("userId") String userId);
 }

--- a/src/main/java/inu/codin/codin/domain/like/controller/LikeFeignClient.java
+++ b/src/main/java/inu/codin/codin/domain/like/controller/LikeFeignClient.java
@@ -14,22 +14,22 @@ import org.springframework.web.bind.annotation.RequestParam;
 
 import java.util.List;
 
-@FeignClient(name = "likeClient", url = "http://localhost:8080")
+@FeignClient(name = "likeClient", url = "${server.feign.url}")
 public interface LikeFeignClient {
 
-    @PostMapping("/likes")
+    @PostMapping
     ResponseEntity<SingleResponse<?>> toggleLike(@RequestBody LikeRequestDto likeRequestDto);
 
-    @GetMapping("/likes")
+    @GetMapping
     Integer getLikeCount(@RequestParam("likeType") LikeType likeType,
                                                      @RequestParam("id") String id);
 
-    @GetMapping("/likes/user")
+    @GetMapping("/user")
     Boolean isUserLiked(@RequestParam("likeType") LikeType likeType,
                                                     @RequestParam("id") String id,
                                                     @RequestParam("userId") String userId);
 
-    @GetMapping("/likes/list")
+    @GetMapping("/list")
     List<LikedResponseDto> getLiked(@RequestParam("likeType") LikeType likeType,
                                     @RequestParam("userId") String userId);
 }

--- a/src/main/java/inu/codin/codin/domain/like/dto/LikeRequestDto.java
+++ b/src/main/java/inu/codin/codin/domain/like/dto/LikeRequestDto.java
@@ -14,5 +14,5 @@ public class LikeRequestDto {
 
     @NotBlank
     @Schema(description = "좋아요를 반영할 entity 의 _id 값", example = "111111")
-    private String id;
+    private String likeTypeId;
 }

--- a/src/main/java/inu/codin/codin/domain/like/dto/LikedResponseDto.java
+++ b/src/main/java/inu/codin/codin/domain/like/dto/LikedResponseDto.java
@@ -1,0 +1,8 @@
+package inu.codin.codin.domain.like.dto;
+
+import lombok.Getter;
+
+@Getter
+public class LikedResponseDto {
+    private String likeTypeId;
+}

--- a/src/main/java/inu/codin/codin/domain/like/service/LikeService.java
+++ b/src/main/java/inu/codin/codin/domain/like/service/LikeService.java
@@ -8,6 +8,7 @@ import inu.codin.codin.domain.like.controller.LikeFeignClient;
 import inu.codin.codin.domain.like.dto.LikeRequestDto;
 import inu.codin.codin.domain.like.dto.LikeResponseType;
 import inu.codin.codin.domain.like.dto.LikeType;
+import inu.codin.codin.domain.like.dto.LikedResponseDto;
 import inu.codin.codin.domain.review.entity.Review;
 import inu.codin.codin.domain.review.exception.ReviewErrorCode;
 import inu.codin.codin.domain.review.exception.ReviewException;
@@ -18,6 +19,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @Slf4j
@@ -96,5 +99,10 @@ public class LikeService {
         } else {
             review.decreaseLikes();
         }
+    }
+
+    public List<LikedResponseDto> getLiked(LikeType likeType) {
+        String userId = SecurityUtils.getUserId();
+        return likeFeignClient.getLiked(likeType, userId);
     }
 }

--- a/src/main/java/inu/codin/codin/domain/like/service/LikeService.java
+++ b/src/main/java/inu/codin/codin/domain/like/service/LikeService.java
@@ -49,7 +49,7 @@ public class LikeService {
             return message;
         } catch (Exception e){ //만약 오류가 났다면 좋아요 추가/취소 (토글) 기능 진행
             log.error("[toggleLike] 예외 발생으로 보상 트랜잭션이 진행됩니다. {}", e.getMessage());
-            if (message != null) LikeResponseType.valueOf((String) likeFeignClient.toggleLike(likeRequestDto).getBody().getData());
+            if (message != null) likeFeignClient.toggleLike(likeRequestDto);
             throw new LikeException(LikeErrorCode.LIKE_UNEXPECTED_MESSAGE, e.getMessage());
         }
     }

--- a/src/main/java/inu/codin/codin/domain/like/service/LikeService.java
+++ b/src/main/java/inu/codin/codin/domain/like/service/LikeService.java
@@ -49,9 +49,9 @@ public class LikeService {
             return message;
         } catch (Exception e){ //만약 오류가 났다면 좋아요 추가/취소 (토글) 기능 진행
             log.error("[toggleLike] 예외 발생으로 보상 트랜잭션이 진행됩니다. {}", e.getMessage());
-            if (message != null) message = LikeResponseType.valueOf((String) likeFeignClient.toggleLike(likeRequestDto).getBody().getData());
+            if (message != null) LikeResponseType.valueOf((String) likeFeignClient.toggleLike(likeRequestDto).getBody().getData());
+            throw new LikeException(LikeErrorCode.LIKE_UNEXPECTED_MESSAGE, e.getMessage());
         }
-        return message;
     }
 
     public int getLikeCount(LikeType likeType, String likeTypeId) {
@@ -78,7 +78,7 @@ public class LikeService {
     }
 
     private void applyLikeChange(LikeRequestDto dto, boolean isLiked) {
-        Long targetId = Long.parseLong(dto.getId());
+        Long targetId = Long.parseLong(dto.getLikeTypeId());
         switch (dto.getLikeType()) {
             case LECTURE -> applyLikeToLecture(targetId, isLiked);
             case REVIEW -> applyLikeToReview(targetId, isLiked);

--- a/src/main/java/inu/codin/codin/domain/review/dto/CreateReviewRequestDto.java
+++ b/src/main/java/inu/codin/codin/domain/review/dto/CreateReviewRequestDto.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Digits;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
 import lombok.Getter;
 
 @Getter
@@ -19,6 +20,7 @@ public class CreateReviewRequestDto {
     private double starRating;
 
     @NotBlank
+    @Pattern(regexp = "^\\d{2}-[1-2]{1}$", message = "학기는 'YY-학기' 형식이어야 합니다. 예: 24-2")
     @Schema(description = "수강 학기 (년도-학기)", example = "24-2")
     private String semester;
 }

--- a/src/main/java/inu/codin/codin/domain/review/entity/Review.java
+++ b/src/main/java/inu/codin/codin/domain/review/entity/Review.java
@@ -26,7 +26,7 @@ public class Review extends BaseEntity {
     @JoinColumn(name = "lecture_id")
     private Lecture lecture;
 
-    @OneToOne
+    @ManyToOne
     @JoinColumn(name = "semester_id")
     private Semester semester;
 

--- a/src/main/java/inu/codin/codin/domain/review/entity/UserReviewStats.java
+++ b/src/main/java/inu/codin/codin/domain/review/entity/UserReviewStats.java
@@ -7,7 +7,6 @@ import jakarta.persistence.Id;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.data.redis.core.index.Indexed;
 
 @Entity
 @Getter
@@ -17,7 +16,6 @@ public class UserReviewStats {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Indexed
     private String userId;
     private int countOfReviews = 0;
     private boolean openKeyword = false;

--- a/src/main/java/inu/codin/codin/domain/review/entity/UserReviewStats.java
+++ b/src/main/java/inu/codin/codin/domain/review/entity/UserReviewStats.java
@@ -1,0 +1,36 @@
+package inu.codin.codin.domain.review.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.redis.core.index.Indexed;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserReviewStats {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Indexed
+    private String userId;
+    private int countOfReviews = 0;
+    private boolean openKeyword = false;
+
+    public UserReviewStats(String userId){
+        this.userId = userId;
+    }
+
+    public void increaseCount(){
+        this.countOfReviews++;
+    }
+
+    public void canOpenKeyword(){
+        this.openKeyword = true;
+    }
+}

--- a/src/main/java/inu/codin/codin/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/inu/codin/codin/domain/review/repository/ReviewRepository.java
@@ -1,6 +1,5 @@
 package inu.codin.codin.domain.review.repository;
 
-import inu.codin.codin.domain.lecture.entity.Emotion;
 import inu.codin.codin.domain.lecture.entity.Lecture;
 import inu.codin.codin.domain.review.entity.Review;
 import org.springframework.data.domain.Page;

--- a/src/main/java/inu/codin/codin/domain/review/repository/UserReviewStatsRepository.java
+++ b/src/main/java/inu/codin/codin/domain/review/repository/UserReviewStatsRepository.java
@@ -1,0 +1,13 @@
+package inu.codin.codin.domain.review.repository;
+
+import inu.codin.codin.domain.review.entity.UserReviewStats;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface UserReviewStatsRepository extends JpaRepository<UserReviewStats, Long> {
+
+    Optional<UserReviewStats> findByUserId(String userId);
+}

--- a/src/main/java/inu/codin/codin/domain/review/service/ReviewService.java
+++ b/src/main/java/inu/codin/codin/domain/review/service/ReviewService.java
@@ -45,6 +45,7 @@ public class ReviewService {
     private final EmotionRepository emotionRepository;
 
     private final LikeService likeService;
+    private final UserReviewStatsService userReviewStatsService;
 
     /**
      * 새로운 강의 후기 작성
@@ -59,13 +60,14 @@ public class ReviewService {
                 .orElseThrow(() -> new LectureException(LectureErrorCode.LECTURE_NOT_FOUND));
 
         String userId = SecurityUtils.getUserId();
-        checkReviewExisted(lectureId, userId, lecture);
+        checkReviewExisted(lectureId, userId, lecture); //리뷰를 작성한 상태인지 확인
 
         Semester semester = getSemester(createReviewRequestDto, lecture);
         Review newReview = Review.of(createReviewRequestDto, semester, lecture, userId);
 
         reviewRepository.save(newReview);
-        updateRating(lecture, createReviewRequestDto.getStarRating());
+        updateRating(lecture, createReviewRequestDto.getStarRating()); //과목의 평점 업데이트
+        userReviewStatsService.updateStats(userId); //유저의 리뷰 작성 현황 업데이트
 
         log.info("새로운 강의 후기 저장 - lectureId : {} userId : {}", lectureId, userId);
     }

--- a/src/main/java/inu/codin/codin/domain/review/service/ReviewService.java
+++ b/src/main/java/inu/codin/codin/domain/review/service/ReviewService.java
@@ -6,8 +6,8 @@ import inu.codin.codin.domain.lecture.entity.Lecture;
 import inu.codin.codin.domain.lecture.entity.Semester;
 import inu.codin.codin.domain.lecture.exception.LectureErrorCode;
 import inu.codin.codin.domain.lecture.exception.LectureException;
-import inu.codin.codin.domain.lecture.repository.EmotionRepository;
 import inu.codin.codin.domain.lecture.repository.LectureRepository;
+import inu.codin.codin.domain.lecture.service.EmotionService;
 import inu.codin.codin.domain.lecture.service.SemesterService;
 import inu.codin.codin.domain.like.dto.LikeType;
 import inu.codin.codin.domain.like.service.LikeService;
@@ -39,8 +39,8 @@ public class ReviewService {
 
     private final ReviewRepository reviewRepository;
     private final LectureRepository lectureRepository;
-    private final EmotionRepository emotionRepository;
 
+    private final EmotionService emotionService;
     private final LikeService likeService;
     private final UserReviewStatsService userReviewStatsService;
     private final SemesterService semesterService;
@@ -92,11 +92,14 @@ public class ReviewService {
      */
     public void updateRating(Lecture lecture, @NotNull @Digits(integer = 1, fraction = 2) double starRating){
         double avgOfStarRating = reviewRepository.getAvgOfStarRatingByLecture(lecture);
-        Emotion emotion = lecture.getEmotion();
-        if (emotion == null) emotion = new Emotion(lecture);
-        emotion.updateScore(starRating);
-        emotionRepository.save(emotion);
+        Emotion emotion = getEmotion(lecture, starRating);
         lecture.updateReviewRating(avgOfStarRating, emotion);
+    }
+
+    private Emotion getEmotion(Lecture lecture, double starRating) {
+        Emotion emotion = emotionService.getOrMakeEmotion(lecture);
+        emotion.updateScore(starRating);
+        return emotion;
     }
 
 

--- a/src/main/java/inu/codin/codin/domain/review/service/UserReviewStatsService.java
+++ b/src/main/java/inu/codin/codin/domain/review/service/UserReviewStatsService.java
@@ -10,21 +10,22 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class UserReviewStatsService {
 
+    private static final int KEYWORD_UNLOCK_THRESHOLD = 3;
     private final UserReviewStatsRepository userReviewStatsRepository;
 
     public void updateStats(String userId) {
         UserReviewStats userReviewStats = userReviewStatsRepository.findByUserId(userId)
                         .orElse(new UserReviewStats(userId));
         userReviewStats.increaseCount();
-        if (!userReviewStats.isOpenKeyword() && userReviewStats.getCountOfReviews() >= 3)
+        if (!userReviewStats.isOpenKeyword() && userReviewStats.getCountOfReviews() >= KEYWORD_UNLOCK_THRESHOLD)
             userReviewStats.canOpenKeyword();
         userReviewStatsRepository.save(userReviewStats);
     }
 
     public boolean isOpenKeyword() {
         String userId = SecurityUtils.getUserId();
-        UserReviewStats userReviewStats = userReviewStatsRepository.findByUserId(userId)
-                        .orElse(new UserReviewStats(userId));
-        return userReviewStats.isOpenKeyword();
+        return userReviewStatsRepository.findByUserId(userId)
+                        .map(UserReviewStats::isOpenKeyword)
+                        .orElse(false);
     }
 }

--- a/src/main/java/inu/codin/codin/domain/review/service/UserReviewStatsService.java
+++ b/src/main/java/inu/codin/codin/domain/review/service/UserReviewStatsService.java
@@ -1,0 +1,30 @@
+package inu.codin.codin.domain.review.service;
+
+import inu.codin.codin.domain.review.entity.UserReviewStats;
+import inu.codin.codin.domain.review.repository.UserReviewStatsRepository;
+import inu.codin.codin.global.auth.util.SecurityUtils;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserReviewStatsService {
+
+    private final UserReviewStatsRepository userReviewStatsRepository;
+
+    public void updateStats(String userId) {
+        UserReviewStats userReviewStats = userReviewStatsRepository.findByUserId(userId)
+                        .orElse(new UserReviewStats(userId));
+        userReviewStats.increaseCount();
+        if (!userReviewStats.isOpenKeyword() && userReviewStats.getCountOfReviews() >= 3)
+            userReviewStats.canOpenKeyword();
+        userReviewStatsRepository.save(userReviewStats);
+    }
+
+    public boolean isOpenKeyword() {
+        String userId = SecurityUtils.getUserId();
+        UserReviewStats userReviewStats = userReviewStatsRepository.findByUserId(userId)
+                        .orElse(new UserReviewStats(userId));
+        return userReviewStats.isOpenKeyword();
+    }
+}

--- a/src/main/java/inu/codin/codin/domain/review/service/UserReviewStatsService.java
+++ b/src/main/java/inu/codin/codin/domain/review/service/UserReviewStatsService.java
@@ -15,7 +15,7 @@ public class UserReviewStatsService {
 
     public void updateStats(String userId) {
         UserReviewStats userReviewStats = userReviewStatsRepository.findByUserId(userId)
-                        .orElse(new UserReviewStats(userId));
+                        .orElseGet(() -> new UserReviewStats(userId));
         userReviewStats.increaseCount();
         if (!userReviewStats.isOpenKeyword() && userReviewStats.getCountOfReviews() >= KEYWORD_UNLOCK_THRESHOLD)
             userReviewStats.canOpenKeyword();

--- a/src/main/java/inu/codin/codin/global/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/inu/codin/codin/global/common/exception/GlobalExceptionHandler.java
@@ -3,6 +3,8 @@ package inu.codin.codin.global.common.exception;
 import inu.codin.codin.domain.lecture.exception.LectureErrorCode;
 import inu.codin.codin.domain.lecture.exception.LectureException;
 import inu.codin.codin.domain.lecture.exception.LectureUploadException;
+import inu.codin.codin.domain.like.exception.LikeErrorCode;
+import inu.codin.codin.domain.like.exception.LikeException;
 import inu.codin.codin.domain.review.exception.ReviewErrorCode;
 import inu.codin.codin.domain.review.exception.ReviewException;
 import inu.codin.codin.global.common.response.ExceptionResponse;
@@ -46,5 +48,13 @@ public class GlobalExceptionHandler {
         ReviewErrorCode reviewErrorCode = e.getErrorCode();
         return ResponseEntity.status(reviewErrorCode.httpStatus())
                 .body(new ExceptionResponse(reviewErrorCode.httpStatus().value(), e.getMessage()));
+    }
+
+    @ExceptionHandler(LikeException.class)
+    protected ResponseEntity<ExceptionResponse> handleLikeException(LikeException e) {
+        LikeErrorCode likeErrorCode = e.getErrorCode();
+        String errorMessage = e.getMessage() + " : " + e.getErrorMessage();
+        return ResponseEntity.status(likeErrorCode.httpStatus())
+                .body(new ExceptionResponse(likeErrorCode.httpStatus().value(), errorMessage));
     }
 }

--- a/src/main/java/inu/codin/codin/global/config/SwaggerConfig.java
+++ b/src/main/java/inu/codin/codin/global/config/SwaggerConfig.java
@@ -47,9 +47,8 @@ public class SwaggerConfig {
                         .addSecuritySchemes("bearerAuth", bearerAuth)
                 )
                 .servers(List.of(
-                        new Server().url("http://localhost:8082").description("Local Server"),
-                        new Server().url(BASE_DOMAIN_URL + "/api").description("Production Server"),
-                        new Server().url(BASE_DOMAIN_URL + "/dev").description("Development Server")
+                        new Server().url("http://localhost:8085").description("Local Server"),
+                        new Server().url(BASE_DOMAIN_URL).description("Production Server")
                 ));
     }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -33,9 +33,11 @@ server:
   port: ${SERVER_PORT}
   domain: ${SERVER_DOMAIN}
   forward-headers-strategy: framework
+  feign:
+    url: ${SERVER_FEIGN_URL}
 
 logging:
   level:
-    root: debug
+    root: info
     sql: info
     org.hibernate.sql: info


### PR DESCRIPTION
> 앞의 PR를 먼저 봐주시고 보시기 바랍니다!!!!!!!!!!!!!!!!
#4 

## ISSUE

#5 

## EXPLAIN

1. 좋아요만 모아보기 기능을 구현하였습니다.
2. 좋아요만 모아보면서도 정렬과 검색 기능이 모두 적용되도록 QueryDSL에 모두 포함시켰습니다.

3. 수강 후기를 3번 이상 단 경우 키워드를 오픈합니다.
4. 지속해서 review에서 count를 진행하는 것보다는 따로 경량 테이블을 제작하여 유저의 후기 작성 현황을 관리하는 것이 낫다고 판단했습니다.
5. 3개 작성한 이후에는 openKeyword의 boolean 값이 true가 되어 해당 값만 판단하면 됩니다.

**07.28 추가 기능**
1. Feign 기능을 개발 서버에 배포하여, 개발 서버와 연동 성공하였습니다. (환경 변수로 feign url 추가)
    - 이후 메인 서버에 배포 시 메인 서버 url로 변경
3. 수강 후기 작성 시 과목 검색 로직을 querydsl로 수정
4. 만약 정렬 기준을 설정하지 않았을 경우의 기본 정렬 추가 (1. 평점 순, 2. 좋아요 순, 3. 조회 순)

## THINK..
키워드 오픈 같은 경우에는 수강신청 기간 시 트래픽이 몰릴 것을 대비하여
추후에 짧은 TTL로 openKeyword 값을 Redis에 저장하여 사용하는 것도 좋을 것 같습니다.

@BHC-Chicken @gisu1102 