### PR TITLE
fix : search error

### DIFF
--- a/src/main/java/inu/codin/codin/domain/elasticsearch/document/LectureDocument.java
+++ b/src/main/java/inu/codin/codin/domain/elasticsearch/document/LectureDocument.java
@@ -13,9 +13,10 @@ import org.springframework.data.elasticsearch.annotations.*;
 
 import java.util.List;
 
-@Document(indexName = "lectures")
 @Getter
 @Builder
+@Document(indexName = "lectures")
+@Setting(settingPath = "elasticsearch/settings/lecture-settings.json")
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class LectureDocument {
 

--- a/src/main/java/inu/codin/codin/domain/elasticsearch/indexer/LectureStartupIndexer.java
+++ b/src/main/java/inu/codin/codin/domain/elasticsearch/indexer/LectureStartupIndexer.java
@@ -15,7 +15,6 @@ import org.springframework.data.elasticsearch.core.IndexOperations;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
-import java.util.Map;
 
 @Slf4j
 @Component
@@ -27,7 +26,7 @@ public class LectureStartupIndexer {
     private final LectureDocumentConverter lectureDocumentConverter;
     private final ElasticsearchOperations elasticsearchOperations; // 추가
 
-    private final int CHUNK_SIZE = 100;
+    private static final int CHUNK_SIZE = 100;
 
     @Value("${elasticsearch.indexer.enabled:true}")
     private boolean indexerEnabled;
@@ -53,8 +52,7 @@ public class LectureStartupIndexer {
         }
 
         log.info("ElasticSearch lectures 인덱스를 생성합니다.");
-        Map<String, Object> settings = createSetting();
-        indexOps.create(settings);
+        indexOps.create();
         indexOps.putMapping(indexOps.createMapping(LectureDocument.class));
         log.info("ElasticSearch lectures 인덱스 및 매핑 생성 완료.");
     }
@@ -87,40 +85,5 @@ public class LectureStartupIndexer {
         elasticsearchOperations.indexOps(LectureDocument.class).refresh();
 
         return totalProcessed;
-    }
-
-    private Map<String, Object> createSetting() {
-        return Map.of(
-                "analysis", Map.of(
-                        "tokenizer", Map.of(
-                                "nori_tokenizer", Map.of(
-                                        "type", "nori_tokenizer",
-                                        "decompound_mode", "mixed"
-                                )
-                        ),
-                        "filter", Map.of(
-                                "nori_readingform", Map.of(
-                                        "type", "nori_readingform"
-                                ),
-                                "autocomplete_filter", Map.of(
-                                        "type", "edge_ngram",
-                                        "min_gram", 1,
-                                        "max_gram", 20
-                                )
-                        ),
-                        "analyzer", Map.of(
-                                "nori", Map.of(
-                                        "type", "custom",
-                                        "tokenizer", "nori_tokenizer",
-                                        "filter", List.of("nori_readingform", "lowercase")
-                                ),
-                                "nori_autocomplete", Map.of(
-                                        "type", "custom",
-                                        "tokenizer", "nori_tokenizer",
-                                        "filter", List.of("nori_readingform", "autocomplete_filter", "lowercase")
-                                )
-                        )
-                )
-        );
     }
 }

--- a/src/main/java/inu/codin/codin/domain/lecture/controller/LectureController.java
+++ b/src/main/java/inu/codin/codin/domain/lecture/controller/LectureController.java
@@ -39,7 +39,7 @@ public class LectureController {
             @RequestParam(value = "department", required = false) Department department,
             @RequestParam(value = "keyword", required = false) String keyword,
             @RequestParam(value = "sort", required = false) SortingOption sort,
-            @RequestParam(value = "like", required = false) Boolean like,
+            @RequestParam(value = "like", defaultValue = "false") Boolean like,
             @RequestParam("page") int page)
     {
         return ResponseEntity.ok().body(new SingleResponse<>(200, "과목 리스트 반환 완료",

--- a/src/main/java/inu/codin/codin/domain/lecture/dto/LectureDetailResponseDto.java
+++ b/src/main/java/inu/codin/codin/domain/lecture/dto/LectureDetailResponseDto.java
@@ -36,8 +36,8 @@ public class LectureDetailResponseDto extends LecturePreviewResponseDto {
 
     private String aiSummary;
 
-    public LectureDetailResponseDto(Long id, String title, String professor, Type type, int grade, int credit, List<String> tags, Department department, Department college, String evaluation, String lectureType, List<Schedule> schedule, List<String> preCourse, EmotionResponseDto emotion, boolean openKeyword, int likes, double starRating, String aiSummary) {
-        super(id, title, professor, type, grade, credit, tags, null, department.getDescription(), likes, starRating);
+    public LectureDetailResponseDto(Long id, String title, String professor, Type type, int grade, int credit, List<String> tags, Department department, Department college, String evaluation, String lectureType, List<Schedule> schedule, List<String> preCourse, EmotionResponseDto emotion, boolean openKeyword, int likes, double starRating, String aiSummary, int hits) {
+        super(id, title, professor, type, grade, credit, tags, null, department.getDescription(), likes, starRating, hits);
         this.college = college.getDescription();
         this.evaluation = evaluation;
         this.lectureType = lectureType;
@@ -69,7 +69,8 @@ public class LectureDetailResponseDto extends LecturePreviewResponseDto {
                 openKeyword,
                 lecture.getLikes(),
                 lecture.getStarRating(),
-                lecture.getAiSummary()
+                lecture.getAiSummary(),
+                lecture.getHits()
         );
     }
     

--- a/src/main/java/inu/codin/codin/domain/lecture/dto/LecturePreviewResponseDto.java
+++ b/src/main/java/inu/codin/codin/domain/lecture/dto/LecturePreviewResponseDto.java
@@ -48,8 +48,11 @@ public class LecturePreviewResponseDto {
     @Schema(description = "평점")
     private double starRating;
 
+    @Schema(description = "조회수")
+    private Integer hits;
+
     @Builder
-    public LecturePreviewResponseDto(Long id, String title, String professor, Type type, int grade, int credit, List<String> tags, Boolean liked, String department, int likes, double starRating) {
+    public LecturePreviewResponseDto(Long id, String title, String professor, Type type, int grade, int credit, List<String> tags, Boolean liked, String department, int likes, double starRating, int hits) {
         this.id = id;
         this.title = title;
         this.professor = professor;
@@ -61,9 +64,10 @@ public class LecturePreviewResponseDto {
         this.department = department;
         this.likes = likes;
         this.starRating = starRating;
+        this.hits = hits;
     }
 
-    public static LecturePreviewResponseDto of(LectureDocument lecture, int likes){
+    public static LecturePreviewResponseDto of(LectureDocument lecture, int likes, boolean liked) {
         return LecturePreviewResponseDto.builder()
                 .id(lecture.getId())
                 .title(lecture.getLectureNm())
@@ -72,9 +76,11 @@ public class LecturePreviewResponseDto {
                 .grade(lecture.getGrade())
                 .credit(lecture.getCredit())
                 .tags((lecture.getTags()))
+                .liked(liked)
                 .department(lecture.getDepartment())
                 .likes(likes)
                 .starRating(lecture.getStarRating())
+                .hits(lecture.getHits())
                 .build();
     }
 

--- a/src/main/java/inu/codin/codin/domain/lecture/entity/Lecture.java
+++ b/src/main/java/inu/codin/codin/domain/lecture/entity/Lecture.java
@@ -1,8 +1,6 @@
 package inu.codin.codin.domain.lecture.entity;
 
-import inu.codin.codin.domain.lecture.converter.EvaluationConverter;
 import inu.codin.codin.domain.lecture.converter.StringListConverter;
-import inu.codin.codin.domain.lecture.converter.TypeConverter;
 import inu.codin.codin.domain.review.entity.Review;
 import inu.codin.codin.global.common.entity.Department;
 import jakarta.persistence.*;
@@ -20,7 +18,8 @@ import java.util.Set;
 @DynamicUpdate
 public class Lecture {
 
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     private String lectureNm;                                   //교과목명
     private int grade;                                          //학년 (0 : 전학년)
@@ -30,11 +29,11 @@ public class Lecture {
     @Enumerated(EnumType.STRING)
     private Department department;                              //학과 (OTHERS : 교양)
 
-    @Convert(converter = TypeConverter.class)
+    @Enumerated(EnumType.STRING)
     private Type type;                                          //수업 유형(전공핵심, 전공선택..)
     private String lectureType;                                 //수업 방식(강의(이론), 온오프라인혼합형..)
 
-    @Convert(converter = EvaluationConverter.class)
+    @Enumerated(EnumType.STRING)
     private Evaluation evaluation;                              //평가 방식(상대평가, 절대평가, 이수)
 
     // Json 형태로 저장
@@ -44,12 +43,16 @@ public class Lecture {
     private int likes;                                          //좋아요 수
     private int hits;                                           //조회 수
 
-    /** 강의 계획서 */
+    /**
+     * 강의 계획서
+     */
     @OneToOne(fetch = FetchType.EAGER)
     @JoinColumn(name = "syllabus_id")
     private Syllabus syllabus;
 
-    /** 교과목 정보 + 강의 계획서 + 리뷰 -> AI 요약 */
+    /**
+     * 교과목 정보 + 강의 계획서 + 리뷰 -> AI 요약
+     */
     @Column(columnDefinition = "TEXT")
     private String aiSummary;
 
@@ -69,11 +72,15 @@ public class Lecture {
     @OneToMany(mappedBy = "lecture", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Review> reviews;                               //수강 후기
 
-    public void increaseLikes() { this.likes++; }
+    public void increaseLikes() {
+        this.likes++;
+    }
 
-    public void decreaseLikes() { this.likes--; }
+    public void decreaseLikes() {
+        this.likes--;
+    }
 
-    public void increaseHits(){
+    public void increaseHits() {
         this.hits++;
     }
 

--- a/src/main/java/inu/codin/codin/domain/lecture/repository/LectureSearchRepositoryCustom.java
+++ b/src/main/java/inu/codin/codin/domain/lecture/repository/LectureSearchRepositoryCustom.java
@@ -11,7 +11,7 @@ import org.springframework.data.domain.Pageable;
 import java.util.List;
 
 public interface LectureSearchRepositoryCustom {
-    Page<LectureDocument> searchLecturesAtPreview(String keyword, Department department, SortingOption sortingOption, List<Long> listList, Pageable pageable, Boolean like);
+    Page<LectureDocument> searchLecturesAtPreview(String keyword, Department department, SortingOption sortingOption, List<String> likeIdList, Pageable pageable, Boolean like);
 
     List<Lecture> searchLecturesAtReview(Department department, Integer grade, Semester semester);
 }

--- a/src/main/java/inu/codin/codin/domain/lecture/repository/LectureSearchRepositoryImpl.java
+++ b/src/main/java/inu/codin/codin/domain/lecture/repository/LectureSearchRepositoryImpl.java
@@ -33,11 +33,12 @@ public class LectureSearchRepositoryImpl implements LectureSearchRepositoryCusto
 
     @Override
     @Transactional(readOnly = true)
-    public Page<LectureDocument> searchLecturesAtPreview(String keyword, Department department, SortingOption sortingOption, List<Long> listList, Pageable pageable, Boolean like) {
-        log.debug("[searchLecturesAtPreview] 강의 조회, keyword={}, department={}, sortingOption={}, liked={}", keyword, department, sortingOption, listList);
-        Page<LectureDocument> lectureDocumentPage = lectureElasticService.searchLectureDocument(keyword, department, sortingOption, listList, pageable.getPageNumber(), pageable.getPageSize(), like);
+    public Page<LectureDocument> searchLecturesAtPreview(String keyword, Department department, SortingOption sortingOption, List<String> likeIdList, Pageable pageable, Boolean like) {
+        log.debug("[searchLecturesAtPreview] 강의 조회, keyword={}, department={}, sortingOption={}, liked={}", keyword, department, sortingOption, like);
+        Page<LectureDocument> lectureDocumentPage = lectureElasticService.searchLectureDocument(keyword, department, sortingOption, likeIdList, pageable.getPageNumber(), pageable.getPageSize(), like);
 
         long total = lectureDocumentPage.getTotalElements();
+
         if (lectureDocumentPage.isEmpty()) {
             return new PageImpl<>(List.of(), pageable, total);
         }

--- a/src/main/java/inu/codin/codin/global/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/inu/codin/codin/global/common/exception/GlobalExceptionHandler.java
@@ -20,10 +20,17 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(Exception.class)
     protected ResponseEntity<ExceptionResponse> handleException(Exception e) {
-        log.warn("[Exception] Class: {}, Error Message : {}, Stack Trace: {}",
-                e.getClass().getSimpleName(),
-                e.getMessage(),
-                e.getStackTrace()[0].toString());
+        StackTraceElement stackTraceElement = e.getStackTrace()[0];
+
+        log.warn("[Exception] 발생 위치: {}.{}({}:{}) | 원인: {} - {}",
+                stackTraceElement.getClassName(),      // 클래스 이름
+                stackTraceElement.getMethodName(),     // 메서드 이름
+                stackTraceElement.getFileName(),         // 파일 이름
+                stackTraceElement.getLineNumber(),       // 라인 번호
+                e.getClass().getSimpleName(),            // 예외 타입
+                e.getMessage()                           // 예외 메시지
+        );
+
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
                 .body(new ExceptionResponse(HttpStatus.INTERNAL_SERVER_ERROR.value(), e.getMessage()));
     }

--- a/src/main/resources/elasticsearch/settings/lecture-settings.json
+++ b/src/main/resources/elasticsearch/settings/lecture-settings.json
@@ -1,0 +1,32 @@
+{
+  "analysis": {
+    "tokenizer": {
+      "nori_tokenizer": {
+        "type": "nori_tokenizer",
+        "decompound_mode": "mixed"
+      }
+    },
+    "filter": {
+      "nori_readingform": {
+        "type": "nori_readingform"
+      },
+      "autocomplete_filter": {
+        "type": "edge_ngram",
+        "min_gram": 1,
+        "max_gram": 20
+      }
+    },
+    "analyzer": {
+      "nori": {
+        "type": "custom",
+        "tokenizer": "nori_tokenizer",
+        "filter": ["nori_readingform", "lowercase"]
+      },
+      "nori_autocomplete": {
+        "type": "custom",
+        "tokenizer": "nori_tokenizer",
+        "filter": ["nori_readingform", "autocomplete_filter", "lowercase"]
+      }
+    }
+  }
+}


### PR DESCRIPTION
1. 서버 실행 오류 해결 (Elasticsearch 인덱스 자동 생성 문제)

문제점: 애플리케이션 실행 시 LectureElasticRepository 빈 생성에 실패하여 UnsatisfiedDependencyException이 발생했습니다. 이는 Spring Data Elasticsearch가 인덱스를 자동 생성할 때, 커스텀 분석기(nori_autocomplete) 설정을 찾지 못해 발생한 mapper_parsing_exception이 원인이었습니다.

해결책: LectureDocument에 @Setting 어노테이션을 추가하여 커스텀 인덱스 설정 파일을 명시적으로 지정했습니다. 이를 통해 Spring이 Repository 빈을 초기화할 때 올바른 설정으로 인덱스를 생성하도록 수정했습니다.

2. Elasticsearch 검색 기능 개선 및 오류 수정

정렬 오류 수정: 존재하지 않는 필드(startRating)로 정렬을 시도하여 발생하던 all shards failed 오류를 starRating으로 수정하여 해결했습니다.

조회수 업데이트 오류 수정: 스크립트 업데이트 시 발생하던 type must not be null 오류를 UpdateQuery 빌더에 withScriptType(ScriptType.INLINE)을 명시하여 해결했습니다.

3. 로직 개선 및 안정성 강화

@RequestParam 기본값 설정: like 파라미터가 요청에 포함되지 않았을 때 null 대신 false가 되도록 defaultValue를 추가하여 NullPointerException 가능성을 차단했습니다.

에러 로깅 개선: GlobalExceptionHandler에서 예외 발생 시, 원인이 된 클래스와 메서드, 라인 번호까지 기록하도록 로그를 상세화하여 디버깅 효율을 높였습니다.