### PR TITLE
fix : elasticsearch add missing

### DIFF
--- a/Dockerfile.es
+++ b/Dockerfile.es
@@ -1,0 +1,4 @@
+FROM docker.elastic.co/elasticsearch/elasticsearch:7.17.13
+
+RUN elasticsearch-plugin install analysis-nori
+

--- a/elastic-docker-compose.yml
+++ b/elastic-docker-compose.yml
@@ -1,14 +1,14 @@
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.17.13
+    build:
+      context: .
+      dockerfile: Dockerfile.es
     container_name: elastic-search
     environment:
       - discovery.type=single-node # 싱글 노드 모드
       - xpack.security.enabled=false # 보안 기능(인증/인가) 끄기
       - "ES_JAVA_OPTS=-Xms512m -Xmx512m" # JVM 힙 사이즈 조정 (메모리 여유에 따라 변경)
       - bootstrap.memory_lock=true
-    command: >
-      bash -c "elasticsearch-plugin install analysis-nori --batch && /usr/local/bin/docker-entrypoint.sh eswrapper"
     ulimits:
       memlock:
         soft: -1

--- a/src/main/java/inu/codin/codin/domain/review/service/ReviewService.java
+++ b/src/main/java/inu/codin/codin/domain/review/service/ReviewService.java
@@ -1,6 +1,7 @@
 package inu.codin.codin.domain.review.service;
 
 
+import inu.codin.codin.domain.elasticsearch.service.LectureElasticService;
 import inu.codin.codin.domain.lecture.entity.Emotion;
 import inu.codin.codin.domain.lecture.entity.Lecture;
 import inu.codin.codin.domain.lecture.entity.Semester;
@@ -39,6 +40,7 @@ public class ReviewService {
 
     private final ReviewRepository reviewRepository;
     private final LectureRepository lectureRepository;
+    private final LectureElasticService lectureElasticService;
 
     private final EmotionService emotionService;
     private final LikeService likeService;
@@ -91,10 +93,11 @@ public class ReviewService {
      * @param lecture 강의 엔티티
      * @param starRating 별점
      */
-    public void updateRating(Lecture lecture, @NotNull @Digits(integer = 1, fraction = 2) double starRating){
+    private void updateRating(Lecture lecture, @NotNull @Digits(integer = 1, fraction = 2) double starRating){
         double avgOfStarRating = reviewRepository.getAvgOfStarRatingByLecture(lecture);
         Emotion emotion = getEmotion(lecture, starRating);
         lecture.updateReviewRating(avgOfStarRating, emotion);
+        lectureElasticService.updateStarRating(lecture.getId(), avgOfStarRating);
     }
 
     private Emotion getEmotion(Lecture lecture, double starRating) {


### PR DESCRIPTION
🔑 주요 변경사항
강의 리뷰가 추가/수정될 때 Elasticsearch LectureDocument의 starRating 필드를 업데이트하는 기능을 추가했습니다.

docker-compose up 실행 시 analysis-nori 플러그인 중복 설치로 인해 발생하던 오류를 해결하고, 설정을 개선했습니다.

상세 변경내용
1. Elasticsearch 별점 업데이트 기능 추가
LectureUpdateService에 updateStarRating 메서드를 추가했습니다.

해당 메서드는 Painless 스크립트를 사용하여 특정 강의 문서의 starRating 필드를 파라미터로 받은 새 평점으로 덮어쓰는 방식으로 동작합니다.

Script: ctx._source.starRating = params.newRating

이를 통해 RDB와 Elasticsearch 간의 데이터 동기화를 유지하여 별점 기반 검색 및 정렬의 정확도를 높였습니다.

2. Docker Compose 실행 오류 수정 및 설정 개선
문제점: 기존 docker-compose.yml 파일은 컨테이너가 시작될 때마다 command를 통해 analysis-nori 플러그인 설치를 시도했습니다. Docker 볼륨으로 인해 플러그인이 이미 설치된 상태에서는 "already exists" 오류가 발생하며 컨테이너가 비정상적으로 시작되었습니다.

해결책:

Elasticsearch 서비스 전용 Dockerfile.es를 추가했습니다.

Dockerfile.es 내에서 RUN 명령어를 사용하여, Docker 이미지를 빌드하는 시점에 단 한 번만 analysis-nori 플러그인을 설치하도록 변경했습니다.

docker-compose.yml 파일이 image를 직접 사용하는 대신, build 설정을 통해 Dockerfile.es를 참조하여 커스텀 이미지를 빌드하도록 수정했습니다.

이를 통해 플러그인 설치 오류를 원천적으로 해결하였습니다.