### PR TITLE
fix: Evaluation 컨버터 추가 및 Type Enumerated 삭제

### DIFF
--- a/src/main/java/inu/codin/codin/domain/lecture/converter/EvaluationConverter.java
+++ b/src/main/java/inu/codin/codin/domain/lecture/converter/EvaluationConverter.java
@@ -1,18 +1,31 @@
 package inu.codin.codin.domain.lecture.converter;
 
 import inu.codin.codin.domain.lecture.entity.Evaluation;
+import inu.codin.codin.domain.lecture.exception.LectureErrorCode;
+import inu.codin.codin.domain.lecture.exception.LectureException;
 import jakarta.persistence.AttributeConverter;
 import jakarta.persistence.Converter;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Converter(autoApply = true)
 public class EvaluationConverter implements AttributeConverter<Evaluation, String> {
     @Override
     public String convertToDatabaseColumn(Evaluation attribute) {
-        return attribute.getDescription();
+        return attribute != null ? attribute.getDescription() : null;
     }
 
     @Override
-    public Evaluation convertToEntityAttribute(String dbData) {
-        return Evaluation.fromDescription(dbData);
+    public Evaluation convertToEntityAttribute(String data) {
+        if (data == null || data.trim().isEmpty()) {
+            return null;
+        }
+
+        try {
+            return Evaluation.fromDescription(data.trim());
+        } catch (IllegalArgumentException e) {
+            log.warn("Evaluation Converter 부분에서 문제가 발생했습니다.");
+            throw new LectureException(LectureErrorCode.CONVERT_ERROR);
+        }
     }
 }

--- a/src/main/java/inu/codin/codin/domain/lecture/entity/Evaluation.java
+++ b/src/main/java/inu/codin/codin/domain/lecture/entity/Evaluation.java
@@ -19,11 +19,20 @@ public enum Evaluation {
 
     @JsonCreator
     public static Evaluation fromDescription(String description) {
+        if (description == null) {
+            return null;
+        }
+
         for (Evaluation evaluation : Evaluation.values()) {
             if (evaluation.getDescription().equals(description)) {
                 return evaluation;
             }
         }
-        return null;
+
+        try {
+            return Evaluation.valueOf(description);
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("Unknown evaluation: " + description);
+        }
     }
 }

--- a/src/main/java/inu/codin/codin/domain/lecture/entity/Lecture.java
+++ b/src/main/java/inu/codin/codin/domain/lecture/entity/Lecture.java
@@ -1,5 +1,6 @@
 package inu.codin.codin.domain.lecture.entity;
 
+import inu.codin.codin.domain.lecture.converter.EvaluationConverter;
 import inu.codin.codin.domain.lecture.converter.StringListConverter;
 import inu.codin.codin.domain.review.entity.Review;
 import inu.codin.codin.global.common.entity.Department;
@@ -28,17 +29,15 @@ public class Lecture {
 
     @Enumerated(EnumType.STRING)
     private Department department;                              //학과 (OTHERS : 교양)
-
-    @Enumerated(EnumType.STRING)
     private Type type;                                          //수업 유형(전공핵심, 전공선택..)
     private String lectureType;                                 //수업 방식(강의(이론), 온오프라인혼합형..)
 
-    @Enumerated(EnumType.STRING)
+    @Convert(converter = EvaluationConverter.class)
     private Evaluation evaluation;                              //평가 방식(상대평가, 절대평가, 이수)
 
     // Json 형태로 저장
     @Convert(converter = StringListConverter.class)
-    private List<String> preCourse;                                   //사전 과목 //todo List로 관리 피룡
+    private List<String> preCourse;                             //사전 과목
     private double starRating;                                  //과목 평점
     private int likes;                                          //좋아요 수
     private int hits;                                           //조회 수


### PR DESCRIPTION
## 관련된 이슈

#26 - 원인 파악 과정을 적은 Issue 입니다.
#23 - 해당 PR에서 Lecture 클래스를 수정하여 발생한 것 같습니다.

---

## 원인

- Evaluation 컨버터가 삭제되어서 JPA no enum constant  에러 발생
- Type 또한 Enumerated 어노테이션이 있어서 no enum constant 에러 발생

## 해결

따라서 전에 수정한 코드 부분을 다시 수정했습니다.
또한, EvaluationConverter에 더 상세한 null 처리를 추가했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 버그 수정
  - 평가 값 변환 시 널/공백 입력을 안전하게 처리하고 NPE를 방지했습니다.
  - 알 수 없는 평가 값 입력에 대해 경고를 기록하고 일관된 오류를 반환합니다.
- 리팩터링
  - 평가 값의 저장/조회 방식을 컨버터 기반으로 정비해 데이터 일관성을 높였습니다.
  - 강의 유형 저장 방식이 프레임워크 기본 동작을 따르도록 정리했습니다.
  - 변환 과정의 로깅을 추가해 진단 가능성을 향상했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->