### PR TITLE
fix: #25 #27 변경사항 적용

### DIFF
--- a/src/main/java/inu/codin/codin/domain/elasticsearch/service/LectureElasticService.java
+++ b/src/main/java/inu/codin/codin/domain/elasticsearch/service/LectureElasticService.java
@@ -76,7 +76,7 @@ public class LectureElasticService {
                 b.filter(f -> f.term(t -> t.field("department").value(department.name())));
             }
 
-            if (like && likeIdList != null && !likeIdList.isEmpty()) {
+            if (Boolean.TRUE.equals(like) && likeIdList != null && !likeIdList.isEmpty()) {
                 b.filter(f -> f.ids(i -> i.values(likeIdList)));
             }
 

--- a/src/main/java/inu/codin/codin/domain/lecture/converter/EvaluationConverter.java
+++ b/src/main/java/inu/codin/codin/domain/lecture/converter/EvaluationConverter.java
@@ -1,18 +1,31 @@
 package inu.codin.codin.domain.lecture.converter;
 
 import inu.codin.codin.domain.lecture.entity.Evaluation;
+import inu.codin.codin.domain.lecture.exception.LectureErrorCode;
+import inu.codin.codin.domain.lecture.exception.LectureException;
 import jakarta.persistence.AttributeConverter;
 import jakarta.persistence.Converter;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Converter(autoApply = true)
 public class EvaluationConverter implements AttributeConverter<Evaluation, String> {
     @Override
     public String convertToDatabaseColumn(Evaluation attribute) {
-        return attribute.getDescription();
+        return attribute != null ? attribute.getDescription() : null;
     }
 
     @Override
-    public Evaluation convertToEntityAttribute(String dbData) {
-        return Evaluation.fromDescription(dbData);
+    public Evaluation convertToEntityAttribute(String data) {
+        if (data == null || data.trim().isEmpty()) {
+            return null;
+        }
+
+        try {
+            return Evaluation.fromDescription(data.trim());
+        } catch (IllegalArgumentException e) {
+            log.warn("Evaluation Converter 부분에서 문제가 발생했습니다.");
+            throw new LectureException(LectureErrorCode.CONVERT_ERROR);
+        }
     }
 }

--- a/src/main/java/inu/codin/codin/domain/lecture/entity/Evaluation.java
+++ b/src/main/java/inu/codin/codin/domain/lecture/entity/Evaluation.java
@@ -19,11 +19,20 @@ public enum Evaluation {
 
     @JsonCreator
     public static Evaluation fromDescription(String description) {
+        if (description == null) {
+            return null;
+        }
+
         for (Evaluation evaluation : Evaluation.values()) {
             if (evaluation.getDescription().equals(description)) {
                 return evaluation;
             }
         }
-        return null;
+
+        try {
+            return Evaluation.valueOf(description);
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("Unknown evaluation: " + description);
+        }
     }
 }

--- a/src/main/java/inu/codin/codin/domain/lecture/entity/Lecture.java
+++ b/src/main/java/inu/codin/codin/domain/lecture/entity/Lecture.java
@@ -1,5 +1,6 @@
 package inu.codin.codin.domain.lecture.entity;
 
+import inu.codin.codin.domain.lecture.converter.EvaluationConverter;
 import inu.codin.codin.domain.lecture.converter.StringListConverter;
 import inu.codin.codin.domain.review.entity.Review;
 import inu.codin.codin.global.common.entity.Department;
@@ -28,17 +29,15 @@ public class Lecture {
 
     @Enumerated(EnumType.STRING)
     private Department department;                              //학과 (OTHERS : 교양)
-
-    @Enumerated(EnumType.STRING)
     private Type type;                                          //수업 유형(전공핵심, 전공선택..)
     private String lectureType;                                 //수업 방식(강의(이론), 온오프라인혼합형..)
 
-    @Enumerated(EnumType.STRING)
+    @Convert(converter = EvaluationConverter.class)
     private Evaluation evaluation;                              //평가 방식(상대평가, 절대평가, 이수)
 
     // Json 형태로 저장
     @Convert(converter = StringListConverter.class)
-    private List<String> preCourse;                                   //사전 과목 //todo List로 관리 피룡
+    private List<String> preCourse;                             //사전 과목
     private double starRating;                                  //과목 평점
     private int likes;                                          //좋아요 수
     private int hits;                                           //조회 수

--- a/src/main/java/inu/codin/codin/global/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/inu/codin/codin/global/common/exception/GlobalExceptionHandler.java
@@ -20,19 +20,25 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(Exception.class)
     protected ResponseEntity<ExceptionResponse> handleException(Exception e) {
-        StackTraceElement stackTraceElement = e.getStackTrace()[0];
+        StackTraceElement[] stack = e.getStackTrace();
 
-        log.warn("[Exception] 발생 위치: {}.{}({}:{}) | 원인: {} - {}",
-                stackTraceElement.getClassName(),      // 클래스 이름
-                stackTraceElement.getMethodName(),     // 메서드 이름
-                stackTraceElement.getFileName(),         // 파일 이름
-                stackTraceElement.getLineNumber(),       // 라인 번호
-                e.getClass().getSimpleName(),            // 예외 타입
-                e.getMessage()                           // 예외 메시지
-        );
+        if (stack != null && stack.length > 0) {
+            StackTraceElement stackTraceElement = stack[0];
+
+            log.error("[Exception] 발생 위치: {}.{}({}:{}) | 원인: {} - {}",
+                    stackTraceElement.getClassName(),
+                    stackTraceElement.getMethodName(),
+                    stackTraceElement.getFileName(),
+                    stackTraceElement.getLineNumber(),
+                    e.getClass().getSimpleName(),
+                    e.getMessage(),
+                    e);
+        } else {
+            log.error("[Exception] 원인: {} - {}", e.getClass().getSimpleName(), e.getMessage(), e);
+        }
 
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                .body(new ExceptionResponse(HttpStatus.INTERNAL_SERVER_ERROR.value(), e.getMessage()));
+                .body(new ExceptionResponse(HttpStatus.INTERNAL_SERVER_ERROR.value(), "서버 내부 오류가 발생했습니다."));
     }
 
     @ExceptionHandler(LectureException.class)


### PR DESCRIPTION
## 연관된 이슈

#25, #27 변경사항 main branch 적용

## 변경 사항

- #27 
  - #26 이슈를 해결했습니다.
- #25 
  - 일반 예외 응답에서 내부 메세지 노출을 차단하였고, 에러 메세지를 로그를 통해 명시하도록 변경했습니다.
  - LectureElasticService 클래스의 searchLectureDocument 메서드에 NPE 처리 로직을 변경했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  * 없음
* 버그 수정
  * 좋아요 필터가 값이 비어있거나 null인 경우에도 안전하게 동작하도록 안정성 개선.
  * 강의 평가 값 처리 로직을 보강해 잘못된 입력에 대한 예외 처리와 안내가 정확해짐.
  * 서버 오류 발생 시 일관된 안내 문구를 반환하고, 드문 상황에서의 예기치 않은 중단을 방지.
* 문서
  * 없음
* 기타
  * 내부 로깅 및 변환 처리의 안정성 강화로 전반적 신뢰성 향상.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->